### PR TITLE
feat: add npm installer entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- add a package bin so the published npm package installs with `npx unbrowse-openclaw install` instead of requiring a repo checkout
+- add `scripts/install-openclaw.sh` so install is one command instead of a plugin install plus manual config surgery
+- add `print-trusted-install` so the README's trusted local-load path is real, not aspirational
+- include `plugins.allow` in the generated config snippet so plugin enablement works on first paste
+- clean up README verification/tool-allowlist guidance to match the shipped plugin behavior
 - align plugin id with the published npm package name `unbrowse-openclaw` so OpenClaw install/update/config references stay consistent
 - ship a native `unbrowse-browser` skill plus `before_agent_start` guidance so OpenClaw treats Unbrowse as the default web path instead of just another tool
 - in strict mode, block the built-in `browser` tool via `before_tool_call`

--- a/README.md
+++ b/README.md
@@ -9,11 +9,46 @@ Use it when you want API-first web work: structured extraction, reverse-engineer
 ## Install
 
 ```bash
-openclaw plugins install unbrowse-openclaw
-openclaw gateway restart
+npx unbrowse-openclaw install --restart
 ```
 
-If that registry install path triggers scary scanner warnings, use the trusted local-load path instead. Review the checked-out plugin, then point OpenClaw at it directly:
+Global package path:
+
+```bash
+npm install -g unbrowse-openclaw
+unbrowse-openclaw install --restart
+```
+
+From this monorepo, the dev wrapper is:
+
+```bash
+bun run openclaw:install -- --restart
+```
+
+What the installer does:
+
+- links the local plugin into OpenClaw
+- merges `plugins.allow` with `unbrowse-openclaw`
+- enables the plugin entry
+- writes sticky plugin config with `routingMode`, `preferInBootstrap`, and timeout
+- unsets global `tools.profile` unless you pass `--keep-tools-profile`
+- optionally restarts the gateway
+
+Why the script exists: `openclaw plugins install` alone is not enough. It does not set `plugins.allow`, does not switch the plugin into strict mode, and does not remove the `tools.profile` footgun that can hide plugin tools completely.
+
+Installer flags:
+
+```bash
+npx unbrowse-openclaw install --mode strict --restart
+npx unbrowse-openclaw install --mode fallback
+npx unbrowse-openclaw install --dev --restart
+npx unbrowse-openclaw install --profile work --restart
+npx unbrowse-openclaw install --keep-tools-profile
+```
+
+The published package depends on `unbrowse`, so the local Unbrowse CLI/runtime is pulled in automatically from npm.
+
+If you still want the manual path, review the checked-out plugin, then point OpenClaw at it directly:
 
 ```json5
 {
@@ -47,18 +82,17 @@ Verify:
 openclaw plugins info unbrowse-openclaw
 openclaw unbrowse-plugin health
 openclaw unbrowse-plugin print-trusted-install
+```
 
 Verify:
-
-```bash
-openclaw plugins info unbrowse-openclaw
-openclaw unbrowse-plugin health
-openclaw unbrowse-plugin print-trusted-install
-```
+- `unbrowse` tool shows up in the agent tool list
+- `openclaw unbrowse-plugin print-bootstrap` prints Unbrowse-first guidance
 
 ## Required Configuration
 
-After installing, several config steps must be completed before an agent can see and call the `unbrowse` tool. Without these, the plugin may register but the tool will be invisible or the gateway will never connect.
+If you use the installer script above, it handles the main config writes automatically. This section is for manual installs and debugging.
+
+After manual install, several config steps must be completed before an agent can see and call the `unbrowse` tool. Without these, the plugin may register but the tool will be invisible or the gateway will never connect.
 
 ### 1. Allow the plugin (REQUIRED)
 
@@ -168,7 +202,7 @@ Example:
 ```json5
 {
   tools: {
-    allow: ["browser", "unbrowse"]
+    allow: ["unbrowse", "unbrowse-openclaw"]
   }
 }
 ```
@@ -200,6 +234,7 @@ Load directly from source with `plugins.load.paths`:
 ## CLI helpers
 
 ```bash
+npx unbrowse-openclaw install --restart
 openclaw unbrowse-plugin health
 openclaw unbrowse-plugin print-bootstrap
 openclaw unbrowse-plugin print-config strict

--- a/README.md
+++ b/README.md
@@ -13,22 +13,104 @@ openclaw plugins install unbrowse-openclaw
 openclaw gateway restart
 ```
 
+If that registry install path triggers scary scanner warnings, use the trusted local-load path instead. Review the checked-out plugin, then point OpenClaw at it directly:
+
+```json5
+{
+  plugins: {
+    allow: ["unbrowse-openclaw"],
+    load: { paths: ["./submodules/openclaw-unbrowse-plugin"] },
+    entries: {
+      "unbrowse-openclaw": {
+        enabled: true,
+        config: {
+          routingMode: "strict",
+          preferInBootstrap: true,
+          timeoutMs: 120000
+        }
+      }
+    }
+  }
+}
+```
+
+Why the install signatures exist:
+
+- `node:child_process` because the plugin launches the local `unbrowse` CLI
+- `process.env` because it passes local config like `UNBROWSE_URL` into that child process
+- local file reads because it loads bundled prompt/skill/config files from its own directory
+- no outbound web traffic happens during install or load; network traffic starts only after an agent explicitly calls `unbrowse`
+
 Verify:
 
 ```bash
 openclaw plugins info unbrowse-openclaw
 openclaw unbrowse-plugin health
+openclaw unbrowse-plugin print-trusted-install
+
+Verify:
+
+```bash
+openclaw plugins info unbrowse-openclaw
+openclaw unbrowse-plugin health
+openclaw unbrowse-plugin print-trusted-install
 ```
 
-If you use plugin allowlists, trust it:
+## Required Configuration
 
-```json5
-{
-  plugins: {
-    allow: ["unbrowse-openclaw"]
-  }
-}
+After installing, several config steps must be completed before an agent can see and call the `unbrowse` tool. Without these, the plugin may register but the tool will be invisible or the gateway will never connect.
+
+### 1. Allow the plugin (REQUIRED)
+
+Non-bundled plugins are not loaded without explicit allowlisting:
+
+```bash
+openclaw config set plugins.allow '["unbrowse-openclaw"]' --strict-json
 ```
+
+Without this, the gateway logs: `plugins.allow is empty; discovered non-bundled plugins may auto-load: unbrowse-openclaw`
+
+### 2. Remove tools.profile (REQUIRED if set)
+
+If your config has a `tools.profile` (e.g. `"coding"`), plugin-registered tools like `unbrowse` will not appear — profiles define a fixed whitelist that does not include plugins.
+
+```bash
+openclaw config unset tools.profile
+```
+
+Verify the tool is visible:
+
+```bash
+openclaw gateway restart
+openclaw agent --local -m "list your tools"
+```
+
+### 3. Enable Telegram plugin (if using Telegram)
+
+The Telegram channel plugin is disabled by default:
+
+```bash
+openclaw plugins enable telegram
+openclaw gateway restart
+```
+
+### 4. Set DM policy (if using Telegram)
+
+The default `dmPolicy: "pairing"` requires manual approval per user. To allow all DMs:
+
+```bash
+openclaw config set channels.telegram.dmPolicy '"open"' --strict-json
+openclaw gateway restart
+```
+
+### 5. Fix permissions (if installed with sudo)
+
+If OpenClaw was installed as root, agent directories may be owned by root:
+
+```bash
+sudo chown -R $(whoami) ~/.openclaw/agents ~/.openclaw/workspace ~/.openclaw/logs
+```
+
 
 ## What agents get
 
@@ -122,6 +204,7 @@ openclaw unbrowse-plugin health
 openclaw unbrowse-plugin print-bootstrap
 openclaw unbrowse-plugin print-config strict
 openclaw unbrowse-plugin print-config fallback
+openclaw unbrowse-plugin print-trusted-install
 ```
 
 ## Dev

--- a/bin/unbrowse-openclaw.mjs
+++ b/bin/unbrowse-openclaw.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageDir = path.resolve(__dirname, "..");
+const installScript = path.join(packageDir, "scripts", "install-openclaw.sh");
+
+function printHelp() {
+  process.stdout.write(`unbrowse-openclaw
+
+Usage:
+  unbrowse-openclaw install [options]
+  npx unbrowse-openclaw install [options]
+
+Commands:
+  install    Install and configure the OpenClaw plugin with sticky Unbrowse routing
+
+Notes:
+  - Package installs default to --copy so npx/global runs do not leave a broken linked path.
+  - The package depends on the npm \`unbrowse\` CLI/runtime automatically.
+  - OpenClaw must already be installed.
+`);
+}
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+if (!command || command === "-h" || command === "--help" || command === "help") {
+  printHelp();
+  process.exit(0);
+}
+
+if (command !== "install") {
+  process.stderr.write(`Unknown command: ${command}\n`);
+  printHelp();
+  process.exit(1);
+}
+
+if (!existsSync(installScript)) {
+  process.stderr.write(`Missing installer: ${installScript}\n`);
+  process.exit(1);
+}
+
+const forwarded = args.slice(1);
+const hasInstallMode = forwarded.includes("--copy") || forwarded.includes("--link");
+const installArgs = [installScript, ...(hasInstallMode ? [] : ["--copy"]), ...forwarded];
+
+const result = spawnSync("bash", installArgs, {
+  cwd: packageDir,
+  stdio: "inherit",
+});
+
+if (result.error) {
+  process.stderr.write(`${String(result.error)}\n`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/index.ts
+++ b/index.ts
@@ -256,10 +256,28 @@ function buildBrowserFallbackBlockReason(): string {
   ].join(" ");
 }
 
+function buildTrustedInstallGuide(mode: "strict" | "fallback"): string {
+  return [
+    "Trusted local-load path:",
+    "1. Review this plugin locally before enabling it.",
+    "2. Load it from disk instead of using a remote registry install.",
+    "",
+    "Why install scanners may warn:",
+    "- `node:child_process` because the plugin launches the local `unbrowse` CLI",
+    "- `process.env` because it passes local config like `UNBROWSE_URL` into that child process",
+    "- local file reads because it loads bundled prompt/skill/config files from its own directory",
+    "- it does not contact external websites during install or load; network traffic starts only after an agent explicitly calls `unbrowse`",
+    "",
+    "Suggested config:",
+    buildSuggestedConfig(mode),
+  ].join("\n");
+}
+
 function buildSuggestedConfig(mode: "strict" | "fallback"): string {
   return [
     "{",
     "  plugins: {",
+    `    allow: ["${PLUGIN_ID}"],`,
     '    load: { paths: ["./submodules/openclaw-unbrowse-plugin"] },',
     "    entries: {",
     `      "${PLUGIN_ID}": {`,
@@ -282,6 +300,7 @@ export const __test = {
   buildBrowserFallbackBlockReason,
   buildBootstrapGuide,
   buildSuggestedConfig,
+  buildTrustedInstallGuide,
   normalizeConfig,
 };
 
@@ -433,6 +452,14 @@ const plugin = {
         .action((mode?: string) => {
           const normalizedMode = mode === "strict" ? "strict" : "fallback";
           process.stdout.write(`${buildSuggestedConfig(normalizedMode)}\n`);
+        });
+
+      command.command("print-trusted-install")
+        .description("Print the recommended local-load install instructions")
+        .argument("[mode]", "strict or fallback", config.routingMode)
+        .action((mode?: string) => {
+          const normalizedMode = mode === "strict" ? "strict" : "fallback";
+          process.stdout.write(`${buildTrustedInstallGuide(normalizedMode)}\n`);
         });
     }, { commands: ["unbrowse-plugin"] });
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "OpenClaw plugin that makes Unbrowse the preferred tool for website tasks.",
   "type": "module",
   "main": "index.ts",
+  "bin": {
+    "unbrowse-openclaw": "./bin/unbrowse-openclaw.mjs"
+  },
   "license": "MIT",
   "author": "Lewis <https://github.com/lekt9>",
   "repository": {
@@ -28,6 +31,7 @@
     "access": "public"
   },
   "scripts": {
+    "install:openclaw": "bash scripts/install-openclaw.sh",
     "test": "node --import tsx --test test/*.test.ts",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run typecheck && npm test"
@@ -55,6 +59,8 @@
     "openclaw.plugin.json",
     "README.md",
     "CHANGELOG.md",
+    "bin",
+    "scripts",
     "prompts",
     "skills",
     "examples",

--- a/scripts/install-openclaw.sh
+++ b/scripts/install-openclaw.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MODE="strict"
+INSTALL_MODE="link"
+RESTART_GATEWAY=0
+KEEP_TOOLS_PROFILE=0
+PLUGIN_PATH=""
+declare -a OPENCLAW_SCOPE=()
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/install-openclaw.sh [options]
+
+Installs and configures the Unbrowse OpenClaw plugin so it stays sticky.
+
+Options:
+  --mode <strict|fallback>  Routing mode to write into plugin config (default: strict)
+  --strict                  Shortcut for --mode strict
+  --fallback                Shortcut for --mode fallback
+  --link                    Link the local plugin path into OpenClaw (default)
+  --copy                    Copy the plugin into OpenClaw instead of linking
+  --restart                 Restart the OpenClaw gateway service after config writes
+  --keep-tools-profile      Do not unset tools.profile
+  --dev                     Target the OpenClaw dev profile
+  --profile <name>          Target a named OpenClaw profile
+  --plugin-path <path>      Override plugin path
+  -h, --help                Show this help
+EOF
+}
+
+log() {
+  printf '[unbrowse-openclaw] %s\n' "$*"
+}
+
+warn() {
+  printf '[unbrowse-openclaw] warn: %s\n' "$*" >&2
+}
+
+die() {
+  printf '[unbrowse-openclaw] error: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      [[ $# -ge 2 ]] || die "--mode requires a value"
+      MODE="$2"
+      shift 2
+      ;;
+    --strict)
+      MODE="strict"
+      shift
+      ;;
+    --fallback)
+      MODE="fallback"
+      shift
+      ;;
+    --link)
+      INSTALL_MODE="link"
+      shift
+      ;;
+    --copy)
+      INSTALL_MODE="copy"
+      shift
+      ;;
+    --restart)
+      RESTART_GATEWAY=1
+      shift
+      ;;
+    --keep-tools-profile)
+      KEEP_TOOLS_PROFILE=1
+      shift
+      ;;
+    --dev)
+      OPENCLAW_SCOPE=(--dev)
+      shift
+      ;;
+    --profile)
+      [[ $# -ge 2 ]] || die "--profile requires a value"
+      OPENCLAW_SCOPE=(--profile "$2")
+      shift 2
+      ;;
+    --plugin-path)
+      [[ $# -ge 2 ]] || die "--plugin-path requires a value"
+      PLUGIN_PATH="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ "$MODE" != "strict" && "$MODE" != "fallback" ]]; then
+  die "--mode must be strict or fallback"
+fi
+
+if [[ -z "$PLUGIN_PATH" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  PLUGIN_PATH="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+PLUGIN_PATH="$(cd "$PLUGIN_PATH" && pwd)"
+
+[[ -f "$PLUGIN_PATH/package.json" ]] || die "package.json not found under $PLUGIN_PATH"
+[[ -f "$PLUGIN_PATH/openclaw.plugin.json" ]] || die "openclaw.plugin.json not found under $PLUGIN_PATH"
+
+command -v openclaw >/dev/null 2>&1 || die "openclaw CLI not found on PATH"
+command -v node >/dev/null 2>&1 || die "node not found on PATH"
+
+PLUGIN_ID="$(
+  node -e '
+    const fs = require("node:fs");
+    const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    process.stdout.write(typeof pkg.name === "string" && pkg.name ? pkg.name : "unbrowse-openclaw");
+  ' "$PLUGIN_PATH/package.json"
+)"
+
+oc() {
+  openclaw "${OPENCLAW_SCOPE[@]}" "$@"
+}
+
+config_get_json() {
+  local path="$1"
+  local value=""
+  value="$(oc config get "$path" --json 2>/dev/null || true)"
+  printf '%s' "$value"
+}
+
+merge_allowlist() {
+  CURRENT_JSON="$1" TARGET_ID="$2" node <<'NODE'
+const raw = (process.env.CURRENT_JSON || "").trim();
+let current = [];
+if (raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) current = parsed.filter((entry) => typeof entry === "string" && entry.trim());
+  } catch {}
+}
+const merged = Array.from(new Set([...current, process.env.TARGET_ID].filter(Boolean)));
+process.stdout.write(JSON.stringify(merged));
+NODE
+}
+
+merge_plugin_config() {
+  CURRENT_JSON="$1" MODE_VALUE="$2" node <<'NODE'
+const raw = (process.env.CURRENT_JSON || "").trim();
+const mode = process.env.MODE_VALUE === "fallback" ? "fallback" : "strict";
+let current = {};
+if (raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) current = parsed;
+  } catch {}
+}
+const timeoutMs = Number.isInteger(current.timeoutMs) ? current.timeoutMs : 120000;
+const merged = {
+  ...current,
+  routingMode: mode,
+  preferInBootstrap: true,
+  allowBrowserFallback: mode === "fallback",
+  timeoutMs,
+};
+process.stdout.write(JSON.stringify(merged));
+NODE
+}
+
+inspect_profile_footguns() {
+  local by_provider_json agents_json
+  by_provider_json="$(config_get_json "tools.byProvider")"
+  agents_json="$(config_get_json "agents.list")"
+
+  CURRENT_JSON="$by_provider_json" node <<'NODE'
+const raw = (process.env.CURRENT_JSON || "").trim();
+if (!raw) process.exit(0);
+try {
+  const parsed = JSON.parse(raw);
+  const offenders = Object.entries(parsed ?? {})
+    .filter(([, value]) => value && typeof value === "object" && typeof value.profile === "string" && value.profile.trim())
+    .map(([key, value]) => `${key}:${value.profile}`);
+  if (offenders.length > 0) {
+    process.stderr.write(
+      `[unbrowse-openclaw] warn: tools.byProvider profiles may still hide plugin tools: ${offenders.join(", ")}\n`,
+    );
+  }
+} catch {}
+NODE
+
+  CURRENT_JSON="$agents_json" node <<'NODE'
+const raw = (process.env.CURRENT_JSON || "").trim();
+if (!raw) process.exit(0);
+try {
+  const parsed = JSON.parse(raw);
+  const offenders = Array.isArray(parsed)
+    ? parsed
+        .map((entry, index) => {
+          const profile = entry?.tools?.profile;
+          const id = typeof entry?.id === "string" && entry.id ? entry.id : `index:${index}`;
+          return typeof profile === "string" && profile.trim() ? `${id}:${profile}` : null;
+        })
+        .filter(Boolean)
+    : [];
+  if (offenders.length > 0) {
+    process.stderr.write(
+      `[unbrowse-openclaw] warn: per-agent tools.profile values may still hide plugin tools: ${offenders.join(", ")}\n`,
+    );
+  }
+} catch {}
+NODE
+}
+
+INSTALL_ARGS=(plugins install "$PLUGIN_PATH")
+if [[ "$INSTALL_MODE" == "link" ]]; then
+  INSTALL_ARGS+=(--link)
+fi
+
+log "installing plugin from $PLUGIN_PATH ($INSTALL_MODE, mode=$MODE)"
+oc "${INSTALL_ARGS[@]}"
+
+ALLOWLIST_JSON="$(merge_allowlist "$(config_get_json "plugins.allow")" "$PLUGIN_ID")"
+ENTRY_CONFIG_JSON="$(merge_plugin_config "$(config_get_json "plugins.entries.$PLUGIN_ID.config")" "$MODE")"
+CURRENT_TOOLS_PROFILE="$(config_get_json "tools.profile")"
+
+log "merging plugins.allow"
+oc config set plugins.allow "$ALLOWLIST_JSON" --strict-json
+
+log "enabling plugin entry"
+oc config set "plugins.entries.$PLUGIN_ID.enabled" "true" --strict-json
+oc config set "plugins.entries.$PLUGIN_ID.config" "$ENTRY_CONFIG_JSON" --strict-json
+
+if [[ "$KEEP_TOOLS_PROFILE" -eq 0 ]]; then
+  if [[ -n "$CURRENT_TOOLS_PROFILE" ]]; then
+    log "unsetting tools.profile so plugin tools stay visible"
+    oc config unset tools.profile >/dev/null
+  fi
+else
+  warn "keeping tools.profile; plugin tools may stay hidden"
+fi
+
+inspect_profile_footguns
+
+if [[ "$RESTART_GATEWAY" -eq 1 ]]; then
+  if oc gateway restart; then
+    log "gateway restarted"
+  else
+    warn "gateway restart failed; run 'openclaw ${OPENCLAW_SCOPE[*]} gateway restart' manually"
+  fi
+else
+  log "restart not requested; run 'openclaw ${OPENCLAW_SCOPE[*]} gateway restart' after install"
+fi
+
+printf '\n'
+log "done"
+log "plugin: $PLUGIN_ID"
+log "mode: $MODE"
+log "path: $PLUGIN_PATH"
+if [[ "$KEEP_TOOLS_PROFILE" -eq 0 ]]; then
+  if [[ -n "$CURRENT_TOOLS_PROFILE" ]]; then
+    log "tools.profile: removed"
+  else
+    log "tools.profile: not set"
+  fi
+fi

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -24,6 +24,7 @@ test("fallback mode config keeps browser available", async () => {
   const snippet = mod.__test.buildSuggestedConfig("fallback");
 
   assert.match(snippet, /"unbrowse-openclaw"/);
+  assert.match(snippet, /allow: \["unbrowse-openclaw"\]/);
   assert.doesNotMatch(snippet, /slots:/);
   assert.doesNotMatch(snippet, /deny: \["browser"\]/);
 });
@@ -76,6 +77,16 @@ test("strict mode block reason points agents back to the Unbrowse path", async (
   assert.match(reason, /Use `unbrowse`/);
 });
 
+test("trusted install guide explains the local-load path", async () => {
+  const mod = await import("../index.ts");
+  const guide = mod.__test.buildTrustedInstallGuide("strict");
+
+  assert.match(guide, /Trusted local-load path/);
+  assert.match(guide, /node:child_process/);
+  assert.match(guide, /process\.env/);
+  assert.match(guide, /allow: \["unbrowse-openclaw"\]/);
+});
+
 test("plugin manifest ships the browser-routing skill", () => {
   const manifest = JSON.parse(
     readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
@@ -86,4 +97,13 @@ test("plugin manifest ships the browser-routing skill", () => {
     readFileSync(new URL("../skills/unbrowse-browser/SKILL.md", import.meta.url), "utf8"),
     /Route website tasks through the Unbrowse-backed browser path/,
   );
+});
+
+test("package exposes the npm installer bin", () => {
+  const pkg = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  ) as { bin?: Record<string, string>; dependencies?: Record<string, string> };
+
+  assert.equal(pkg.bin?.["unbrowse-openclaw"], "./bin/unbrowse-openclaw.mjs");
+  assert.equal(pkg.dependencies?.unbrowse, "^1.1.5");
 });


### PR DESCRIPTION
## Summary
- add a published npm bin so users can run `npx unbrowse-openclaw install --restart`
- keep the sticky OpenClaw config installer in-package and document the npm-first flow
- add coverage for the package bin and install guidance

## Verification
- npm test
- npm run typecheck
- npm pack --dry-run
- node bin/unbrowse-openclaw.mjs install --profile <temp-profile>